### PR TITLE
silent the "subroutine redefined" warnings from mixins

### DIFF
--- a/lib/Jifty/DBI/Record/Plugin.pm
+++ b/lib/Jifty/DBI/Record/Plugin.pm
@@ -179,7 +179,11 @@ sub import {
         $caller->_init_methods_for_column($_);
         $caller->COLUMNS->{ $_->name } = $_ unless $_->virtual;
     }
-    $self->export_to_level(1,undef);
+    {
+        # this prevents the redefine warnings
+        local ($^W) = 0;
+        $self->export_to_level(1,undef);
+    }
     
     if (my $triggers =  $self->can('register_triggers') ) {
         $triggers->($caller)


### PR DESCRIPTION
most likely coming from plugin::openid where has_alternative_auth can be defined in different places
