### PR TITLE
Added strict and warnings to Oracle.pm

### DIFF
--- a/lib/Jifty/DBI/Handle/Oracle.pm
+++ b/lib/Jifty/DBI/Handle/Oracle.pm
@@ -1,4 +1,8 @@
 package Jifty::DBI::Handle::Oracle;
+
+use strict;
+use warnings;
+
 use base qw/Jifty::DBI::Handle/;
 use DBD::Oracle qw(:ora_types ORA_OCI);
 


### PR DESCRIPTION
This should help with the Kwalitee score at http://cpants.cpanauthors.org/dist/Jifty-DBI but I haven't been able to do any testing on the effects, as it requires having Oracle things installed. Some changes may be needed to get the module passing strict and running without throwing warnings.
